### PR TITLE
Added GMP dependency.

### DIFF
--- a/worker/fedora-26.Dockerfile
+++ b/worker/fedora-26.Dockerfile
@@ -30,6 +30,7 @@ RUN dnf install -y \
         numpy \
         scipy \
         python3-scipy \
+        gmp-devel \
 # IO libraries
         SDL-devel \
         alsa-lib-devel \


### PR DESCRIPTION
explicit dependency on Ubuntu, not on Fedora so far, but necessary to build
scheduler with fractional offsets.