### PR TITLE
Add a timeout to ctest

### DIFF
--- a/config_module/builders/build_GR.py
+++ b/config_module/builders/build_GR.py
@@ -67,7 +67,7 @@ def build_and_test():
 
     @util.renderer
     def parse_test_excludes(props):
-        command = ["ctest", "--output-on-failure"]
+        command = ["ctest", "--output-on-failure", "--timeout", "30"]
         excludes = props.getProperty("test_excludes", None)
         if excludes is not None:
             command += ["-E", "|".join(excludes)]

--- a/config_module/builders/build_volk.py
+++ b/config_module/builders/build_volk.py
@@ -67,7 +67,7 @@ def build_and_test():
 
     @util.renderer
     def parse_test_excludes(props):
-        command = ["ctest", "--output-on-failure"]
+        command = ["ctest", "--output-on-failure", "--timeout", "10"]
         excludes = props.getProperty("test_excludes", None)
         if excludes is not None:
             command += ["-E", "|".join(excludes)]


### PR DESCRIPTION
deadlocking unit tests currently lead to a lockup of the test for a long
time.
This should limit each VOLK test to 10 s, and each GR test to 30 s,
which hopefully is long enough (we should probably avoid unit tests that
take longer, anyways!).