### PR TITLE
workers: libqwt-qt5-dev dependency added to ubuntu-18.04

### DIFF
--- a/worker/ubuntu-18.04.Dockerfile
+++ b/worker/ubuntu-18.04.Dockerfile
@@ -100,6 +100,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libqt4-dev \
        libqwt-dev \
        libqwt5-qt4 \
+       libqwt-qt5-dev \
        qtbase5-dev \
        libsdl1.2-dev \
        libuhd-dev \


### PR DESCRIPTION
this fixes https://github.com/gnuradio/gnuradio-buildbot/issues/18