### PR TITLE
Fedora: add gr-vocoder GSM, Codec2 dependencies

### DIFF
--- a/worker/fedora-26.Dockerfile
+++ b/worker/fedora-26.Dockerfile
@@ -42,6 +42,9 @@ RUN dnf install -y \
 ## Gnuradio deprecated gr-comedi
 ## http://gnuradio.org/redmine/issues/show/395
         comedilib-devel \
+## Vocoder libraries
+        codec2-devel \
+        gsm-devel \
 # ctrlport - thrift
         thrift \
         thrift-devel \

--- a/worker/fedora-28.Dockerfile
+++ b/worker/fedora-28.Dockerfile
@@ -42,6 +42,9 @@ RUN dnf install -y \
 ## Gnuradio deprecated gr-comedi
 ## http://gnuradio.org/redmine/issues/show/395
         comedilib-devel \
+## Vocoder libraries
+        codec2-devel \
+        gsm-devel \
 # ctrlport - thrift
         thrift \
         thrift-devel \

--- a/worker/fedora-29.Dockerfile
+++ b/worker/fedora-29.Dockerfile
@@ -42,6 +42,9 @@ RUN dnf install -y \
 ## Gnuradio deprecated gr-comedi
 ## http://gnuradio.org/redmine/issues/show/395
         comedilib-devel \
+## Vocoder libraries
+        codec2-devel \
+        gsm-devel \
 # ctrlport - thrift
         thrift \
         thrift-devel \


### PR DESCRIPTION
Since these are optional dependencies, this never lead to warnings, but
always ignored bugs that might have been in gr-vocoder.

Closes #23