### PR TITLE
enable builders for the pybind base branch

### DIFF
--- a/config_module/builders/builders.json
+++ b/config_module/builders/builders.json
@@ -130,8 +130,25 @@
                     "scheds": ["coverity"],
                     "runners": ["time"]
                 }
-
-
+            ]
+        },
+        "pybind":{
+            "builds":[
+                {
+                    "opts": ["python3", "qt5"],
+                    "scheds": ["Ubuntu_18_04_64", "Fedora_29", "Debian_10_64"],
+                    "runners": ["pull"]
+                },
+                {
+                    "opts": ["python3", "qt5"],
+                    "scheds": ["Ubuntu_18_04_64", "Fedora_29", "Centos_7_6", "Debian_10_64"],
+                    "runners": ["push", "time"]
+                },
+                {
+                    "opts": ["python3", "coverity"],
+                    "scheds": ["coverity"],
+                    "runners": ["time"]
+                }
             ]
         }
     }


### PR DESCRIPTION
Having this would be *very* awesome for pybind/SWIG replacement development