### PR TITLE
workers: add libsndfile to docker images

### DIFF
--- a/worker/debian-10.Dockerfile
+++ b/worker/debian-10.Dockerfile
@@ -25,6 +25,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
   libportaudio2 \
   libqwt6abi1 \
   libsdl-image1.2 \
+  libsndfile1-dev \
   libuhd3.13.1 \
   libusb-1.0-0 \
   libzmq5 \

--- a/worker/fedora-29.Dockerfile
+++ b/worker/fedora-29.Dockerfile
@@ -36,6 +36,7 @@ RUN dnf install -y \
         SDL-devel \
         alsa-lib-devel \
         portaudio-devel \
+        libsndfile-devel \
 # because fedora is too stupid to install dependencies
        jack-audio-connection-kit \
         cppzmq-devel \

--- a/worker/fedora-30.Dockerfile
+++ b/worker/fedora-30.Dockerfile
@@ -41,6 +41,7 @@ RUN echo "zchunk=false" >> /etc/dnf/dnf.conf && \
         alsa-lib-devel \
         portaudio-devel \
         jack-audio-connection-kit \
+        libsndfile-devel \
         uhd-devel \
         log4cpp-devel \
 ## Vocoder libraries

--- a/worker/ubuntu-18.04.Dockerfile
+++ b/worker/ubuntu-18.04.Dockerfile
@@ -26,6 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libportaudio2 \
          libqwt6abi1 \
          libsdl-image1.2 \
+         libsndfile1-dev \
          libuhd003.010.003 \
          libusb-1.0-0 \
          libzmq5 \


### PR DESCRIPTION
https://github.com/gnuradio/gnuradio/pull/3600 described by https://github.com/gnuradio/gnuradio/issues/3577 adds libnsndfile as a dependency.  CI won't run until libsndfile1 is added into the docker images